### PR TITLE
Add behance reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "be-karma-stacktrace-transforms": "~1.0.1",
     "be-paige": "0.3.2",
     "fork-pool": "0.0.2",
     "grunt-contrib-jshint": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "grunt-scss-lint": "0.1.5",
     "grunt-shell": "0.6.4",
     "karma": "~0.12.0",
+    "karma-be-reporter": "~1.0.0",
     "karma-chrome-launcher": "~0.1.0",
     "karma-coffee-preprocessor": "~0.1.0",
     "karma-coverage": "~0.2.7",


### PR DESCRIPTION
I wanted karma stacktraces to have less noise. Rolling a custom reporter that extends a user-specified reporter (karma-mocha-reporter, in our case) was the least invasive way to achieve that. 

This PR makes stacktraces more useful with the extensibility to apply custom transforms and custom reporter features.

It makes stacktraces look like:

![screen shot 2015-02-10 at 2 24 37 pm](https://cloud.githubusercontent.com/assets/865203/6134637/bebee14c-b130-11e4-876e-599832543b94.png)
