### PR TITLE
Update build-layer-lint version to 0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "be-karma-stacktrace-transforms": "~1.0.1",
     "be-paige": "0.3.2",
-    "build-layer-lint": "0.1.0",
+    "build-layer-lint": "0.2.0",
     "fork-pool": "0.0.2",
     "grunt-contrib-jshint": "0.8.0",
     "grunt-jscs": "1.2.0",


### PR DESCRIPTION
This shouldn't be merged until https://github.com/behance/node-build-layer-lint/pull/1 is merged